### PR TITLE
Small fixes

### DIFF
--- a/src/xt_fiddle/client.cljs
+++ b/src/xt_fiddle/client.cljs
@@ -151,6 +151,7 @@
 (defn language-dropdown []
   [dropdown {:items [{:value :xtql :label "XTQL"}
                      {:value :sql :label "SQL"}]
+             :selected @(rf/subscribe [:get-type])
              :on-click #(rf/dispatch [:dropdown-selection (:value %)])
              :label (case @(rf/subscribe [:get-type])
                       :xtql "XTQL"

--- a/src/xt_fiddle/client.cljs
+++ b/src/xt_fiddle/client.cljs
@@ -250,20 +250,25 @@
                      :xtql editor/clj-editor
                      :sql editor/sql-editor)]
         [:<>
-         [:div {:class "flex-1 border overflow-scroll"}
-          [editor {:source @(rf/subscribe [:txs])
-                   :change-callback #(rf/dispatch [:set-txs %])}]]
-         [:div {:class "flex-1 border overflow-scroll"}
-          [editor {:source @(rf/subscribe [:query])
-                   :change-callback #(rf/dispatch [:set-query %])}]]])]
-     [:section {:class "h-1/2 border p-2 overflow-auto"}
-      "Results:"
-      (if @(rf/subscribe [:twirly?])
-        [spinner]
-        (let [{:keys [results failure]} @(rf/subscribe [:results-or-failure])]
-          (if failure
-            [display-error failure]
-            [display-table results @(rf/subscribe [:get-type])])))]]]])
+         [:div {:class "flex-1 flex flex-col"}
+          [:h2 "Transactions:"]
+          [:div {:class "grow"}
+           [editor {:source @(rf/subscribe [:txs])
+                    :change-callback #(rf/dispatch [:set-txs %])}]]]
+         [:div {:class "flex-1 flex flex-col"}
+          [:h2 "Query:"]
+          [:div {:class "grow"}
+           [editor {:source @(rf/subscribe [:query])
+                    :change-callback #(rf/dispatch [:set-query %])}]]]])]
+     [:section {:class "h-1/2 flex flex-col"}
+      [:h2 "Results:"]
+      [:div {:class "grow border p-2 overflow-auto"}
+       (if @(rf/subscribe [:twirly?])
+         [spinner]
+         (let [{:keys [results failure]} @(rf/subscribe [:results-or-failure])]
+           (if failure
+             [display-error failure]
+             [display-table results @(rf/subscribe [:get-type])])))]]]]])
 
 ;; start is called by init and after code reloading finishes
 (defn ^:dev/after-load start! []

--- a/src/xt_fiddle/client.cljs
+++ b/src/xt_fiddle/client.cljs
@@ -249,10 +249,10 @@
                      :xtql editor/clj-editor
                      :sql editor/sql-editor)]
         [:<>
-         [:div {:class "flex flex-1 border overflow-scroll"}
+         [:div {:class "flex-1 border overflow-scroll"}
           [editor {:source @(rf/subscribe [:txs])
                    :change-callback #(rf/dispatch [:set-txs %])}]]
-         [:div {:class "flex flex-1 border overflow-scroll"}
+         [:div {:class "flex-1 border overflow-scroll"}
           [editor {:source @(rf/subscribe [:query])
                    :change-callback #(rf/dispatch [:set-query %])}]]])]
      [:section {:class "h-1/2 border p-2 overflow-auto"}

--- a/src/xt_fiddle/client.cljs
+++ b/src/xt_fiddle/client.cljs
@@ -35,9 +35,9 @@
 (rf/reg-event-fx
   :app/init
   [(rf/inject-cofx ::query-params/get)]
-  (fn [{:keys [_db] {:keys [type txs query]} :query-params}
-       _]
-    (let [type (if type (keyword type) :sql)]
+  (fn [{:keys [query-params]} _]
+    (let [{:keys [type txs query]} query-params
+          type (if type (keyword type) :sql)]
       {:db {:type type
             :txs (if txs
                    (js/atob txs)

--- a/src/xt_fiddle/client.cljs
+++ b/src/xt_fiddle/client.cljs
@@ -165,7 +165,7 @@
 (def default-xtql-query "(from :docs [xt/id foo])")
 
 (def default-sql-insert "INSERT INTO docs (xt$id, foo) VALUES (1, 'bar')")
-(def default-sql-query "SELECT docs.xt$id, docs.name FROM docs")
+(def default-sql-query "SELECT docs.xt$id, docs.foo FROM docs")
 
 (defn page-spinner []
   [:div {:class "fixed flex items-center justify-center h-screen w-screen bg-white/80 z-50"}

--- a/src/xt_fiddle/dropdown.cljs
+++ b/src/xt_fiddle/dropdown.cljs
@@ -1,0 +1,43 @@
+(ns xt-fiddle.dropdown
+  (:require [reagent.core :as r]))
+
+(defn dropdown [{:keys [label items on-click]}]
+  (r/with-let [id (str (gensym "dropdown"))
+               open? (r/atom false)
+              ; Close the dropdown if the user clicks outside of it
+               click-handler (fn [event]
+                               (let [dropdown-elem (js/document.querySelector (str "#" id))]
+                                 (when (not (.contains dropdown-elem (.-target event)))
+                                   (reset! open? false))))
+               _ (js/window.addEventListener "click" click-handler)]
+    [:div {:class "relative inline-block text-left"}
+     [:button {:type "button"
+               :class "inline-flex justify-center w-full px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-sm shadow-sm hover:bg-gray-50 focus:outline-none"
+               :id id
+               :data-dropdown-toggle "dropdown"
+               :on-change #(reset! open? false)
+               :on-click #(swap! open? not)}
+      label
+      [:svg {:class "w-4 h-4 ml-2"
+             :xmlns "http://www.w3.org/2000/svg"
+             :fill "none"
+             :viewBox "0 0 24 24"
+             :stroke "currentColor"
+             :aria-hidden "true"}
+       [:path
+        {:stroke-linecap "round" :stroke-linejoin "round" :stroke-width "2" :d "M19 9l-7 7-7-7"}]]]
+
+     (when @open?
+       [:div {:class "z-10 absolute w-44 bg-white divide-y divide-gray-100 shadow dark:bg-gray-700"}
+        [:ul {:class "py-1 text-sm text-gray-700 dark:text-gray-200" :aria-labelledby "dropdownDefault"}
+         (for [{:keys [value label] :as item} items]
+           ^{:key value}
+           [:li
+            [:a {:href "#" :class  "block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
+                 :on-click (fn [event]
+                             (.preventDefault event)
+                             (on-click item)
+                             (reset! open? false))}
+             label]])]])]
+    (finally
+      (js/window.removeEventListener "click" click-handler))))

--- a/src/xt_fiddle/dropdown.cljs
+++ b/src/xt_fiddle/dropdown.cljs
@@ -1,7 +1,7 @@
 (ns xt-fiddle.dropdown
   (:require [reagent.core :as r]))
 
-(defn dropdown [{:keys [label items on-click]}]
+(defn dropdown [{:keys [label selected items on-click]}]
   (r/with-let [id (str (gensym "dropdown"))
                open? (r/atom false)
               ; Close the dropdown if the user clicks outside of it
@@ -30,14 +30,20 @@
      (when @open?
        [:div {:class "z-10 absolute w-44 bg-white divide-y divide-gray-100 shadow dark:bg-gray-700"}
         [:ul {:class "py-1 text-sm text-gray-700 dark:text-gray-200" :aria-labelledby "dropdownDefault"}
-         (for [{:keys [value label] :as item} items]
-           ^{:key value}
-           [:li
-            [:a {:href "#" :class  "block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
-                 :on-click (fn [event]
-                             (.preventDefault event)
-                             (on-click item)
-                             (reset! open? false))}
-             label]])]])]
+         (doall
+          (for [{:keys [value label] :as item} items]
+            ^{:key value}
+            [:li
+             [:a {:href "#"
+                  :class (str "block px-4 py-2 "
+                              (if (= selected value)
+                                "bg-gray-100 text-gray-400 cursor-default"
+                                "hover:bg-gray-200 dark:hover:bg-gray-600 dark:hover:text-white"))
+                  :on-click (fn [event]
+                              (.preventDefault event)
+                              (when-not (= selected value)
+                                (on-click item))
+                              (reset! open? false))}
+              label]]))]])]
     (finally
       (js/window.removeEventListener "click" click-handler))))

--- a/src/xt_fiddle/editor.cljs
+++ b/src/xt_fiddle/editor.cljs
@@ -35,26 +35,28 @@
                                        (when (.-changes update)
                                          (callback (.. update -state -doc toString))))))
 
-(defonce clj-extensions #js [theme
-                             (history)
-                             (syntaxHighlighting defaultHighlightStyle)
-                             (view/drawSelection)
-                             (foldGutter)
-                             (.. EditorState -allowMultipleSelections (of true))
-                             cm-clj/default-extensions
-                             (.of view/keymap cm-clj/complete-keymap)
-                             (.of view/keymap historyKeymap)])
+(defonce clj-extensions
+  #js [theme
+       (history)
+       (syntaxHighlighting defaultHighlightStyle)
+       (view/drawSelection)
+       (foldGutter)
+       (.. EditorState -allowMultipleSelections (of true))
+       cm-clj/default-extensions
+       (.of view/keymap cm-clj/complete-keymap)
+       (.of view/keymap historyKeymap)])
 
-(def sql-extensions #js [theme
-                         (history)
-                         (syntaxHighlighting defaultHighlightStyle)
-                         (view/drawSelection)
-                         (foldGutter)
-                         (.. EditorState -allowMultipleSelections (of true))
-                         (.of view/keymap historyKeymap)
-                         StandardSQL
-                         (.. StandardSQL -language -data (of #js {:autocomplete (keywordCompletionSource StandardSQL true)}))
-                         #_(autocompletion #js {:override #js [(keywordCompletionSource PostgreSQL true)]})])
+(def sql-extensions
+  #js [theme
+       (history)
+       (syntaxHighlighting defaultHighlightStyle)
+       (view/drawSelection)
+       (foldGutter)
+       (.. EditorState -allowMultipleSelections (of true))
+       (.of view/keymap historyKeymap)
+       StandardSQL
+       (.. StandardSQL -language -data (of #js {:autocomplete (keywordCompletionSource StandardSQL true)}))
+       #_(autocompletion #js {:override #js [(keywordCompletionSource PostgreSQL true)]})])
 
 (defn editor [{:keys [extensions]}]
   (fn [{:keys [source change-callback]}]

--- a/src/xt_fiddle/editor.cljs
+++ b/src/xt_fiddle/editor.cljs
@@ -4,7 +4,7 @@
             ["@codemirror/language" :refer [foldGutter syntaxHighlighting defaultHighlightStyle]]
             ["@codemirror/lang-sql" :as sql :refer [PostgreSQL StandardSQL keywordCompletionSource]]
             ["@codemirror/state" :refer [EditorState]]
-            ["@codemirror/view" :as view :refer [EditorView]]
+            ["@codemirror/view" :as view :refer [EditorView lineNumbers]]
             [applied-science.js-interop :as j]
             [nextjournal.clojure-mode :as cm-clj]
             [nextjournal.clojure-mode.test-utils :as test-utils]
@@ -41,6 +41,7 @@
        (syntaxHighlighting defaultHighlightStyle)
        (view/drawSelection)
        (foldGutter)
+       (lineNumbers)
        (.. EditorState -allowMultipleSelections (of true))
        cm-clj/default-extensions
        (.of view/keymap cm-clj/complete-keymap)
@@ -52,6 +53,7 @@
        (syntaxHighlighting defaultHighlightStyle)
        (view/drawSelection)
        (foldGutter)
+       (lineNumbers)
        (.. EditorState -allowMultipleSelections (of true))
        (.of view/keymap historyKeymap)
        StandardSQL

--- a/src/xt_fiddle/editor.cljs
+++ b/src/xt_fiddle/editor.cljs
@@ -68,6 +68,9 @@
 (defn make-state [{:keys [doc extensions]}]
   (.create EditorState #js{:doc doc :extensions (clj->js extensions)}))
 
+;; NOTE: There's a bug here: changes to `source` aren't represented in the editor.
+;;       I can't think of a way around this right now :/
+;;       I'm going to "fix" it by trying to make sure this doesn't happen
 (defn editor [{:keys [extensions]}]
   (fn [{:keys [source change-callback]}]
     (r/with-let [!view (r/atom nil)

--- a/src/xt_fiddle/editor.cljs
+++ b/src/xt_fiddle/editor.cljs
@@ -74,16 +74,20 @@
 (defn editor [{:keys [extensions]}]
   (fn [{:keys [source change-callback]}]
     (r/with-let [!view (r/atom nil)
+                 ; NOTE: This must be defined in the with-let
+                 ;       If put under :ref then it's called every time
+                 ;       the component is re-rendered.
+                 ;       This would create multiple instances of the editor.
                  mount! (fn [el]
                           (when el
-                            (reset! !view
-                                    (let [extensions [extensions
-                                                      (on-change change-callback)]
-                                          state (make-state {:doc source
-                                                             :extensions extensions})]
-                                      (make-view
-                                       {:parent el
-                                        :state state})))))]
+                            (let [extensions [extensions
+                                              (on-change change-callback)]
+                                  state (make-state
+                                         {:doc source
+                                          :extensions extensions})]
+                              (reset! !view (make-view
+                                             {:parent el
+                                              :state state})))))]
       [:div {:class "h-full"
              :ref mount!}]
       (finally

--- a/src/xt_fiddle/editor.cljs
+++ b/src/xt_fiddle/editor.cljs
@@ -88,7 +88,7 @@
                               (reset! !view (make-view
                                              {:parent el
                                               :state state})))))]
-      [:div {:class "h-full"
+      [:div {:class "h-full border overflow-scroll"
              :ref mount!}]
       (finally
         (j/call @!view :destroy)))))

--- a/src/xt_fiddle/editor.cljs
+++ b/src/xt_fiddle/editor.cljs
@@ -11,7 +11,8 @@
 
 (def theme
   (.theme EditorView
-          (j/lit {".cm-content" {:white-space "pre-wrap"
+          (j/lit {"&.cm-editor" {:height "100%"}
+                  ".cm-content" {:white-space "pre-wrap"
                                  :padding "10px 0"
                                  :flex "1 1 0"}
 
@@ -78,7 +79,8 @@
                                       (make-view
                                        {:parent el
                                         :state state})))))]
-      [:div {:ref mount!}]
+      [:div {:class "h-full"
+             :ref mount!}]
       (finally
         (j/call @!view :destroy)))))
 

--- a/src/xt_fiddle/editor.cljs
+++ b/src/xt_fiddle/editor.cljs
@@ -57,7 +57,7 @@
                          #_(autocompletion #js {:override #js [(keywordCompletionSource PostgreSQL true)]})])
 
 (defn editor [{:keys [extensions]}]
-  (fn [source {:keys [change-callback]}]
+  (fn [{:keys [source change-callback]}]
     (r/with-let [!view (r/atom nil)
                  mount! (fn [el]
                           (when el

--- a/src/xt_fiddle/editor.cljs
+++ b/src/xt_fiddle/editor.cljs
@@ -24,8 +24,10 @@
                   ".cm-matchingBracket" {:border-bottom "1px solid var(--teal-color)"
                                          :color "inherit"}
                   ".cm-gutters" {:background "transparent"
-                                 :border "none"}
-                  ".cm-gutterElement" {:margin-left "5px"}
+                                 :padding "0 9px"
+                                 :line-height "1.6"
+                                 :font-size "16px"
+                                 :font-family "var(--code-font)"}
                   ;; only show cursor when focused
                   ".cm-cursor" {:visibility "hidden"}
                   "&.cm-focused .cm-cursor" {:visibility "visible"}})))


### PR DESCRIPTION
- Update the default SQL query
- Add line numbers
- Fix `>` being stripped from clojure code
- Display results in a table
  - In XTQL view, map values are displayed as edn
  - In SQL view, map values are displayed as json
- Make the editor fill the view
- Style the gutters
- Add a work around fix for clicking the same language twice getting the editor out of sync
- Adds titles to the boxes so it's clearer what they're for

Fixes #7