### PR TITLE
Fix some small bugs

### DIFF
--- a/src/xt_fiddle/client.cljs
+++ b/src/xt_fiddle/client.cljs
@@ -253,17 +253,19 @@
         [:<>
          [:div {:class "flex-1 flex flex-col"}
           [:h2 "Transactions:"]
-          [:div {:class "grow"}
+          ; NOTE: The min-h-0 somehow makes sure the editor doesn't
+          ;       overflow the flex container
+          [:div {:class "grow min-h-0"}
            [editor {:source @(rf/subscribe [:txs])
                     :change-callback #(rf/dispatch [:set-txs %])}]]]
          [:div {:class "flex-1 flex flex-col"}
           [:h2 "Query:"]
-          [:div {:class "grow"}
+          [:div {:class "grow min-h-0"}
            [editor {:source @(rf/subscribe [:query])
                     :change-callback #(rf/dispatch [:set-query %])}]]]])]
      [:section {:class "h-1/2 flex flex-col"}
       [:h2 "Results:"]
-      [:div {:class "grow border p-2 overflow-auto"}
+      [:div {:class "grow min-h-0 border p-2 overflow-auto"}
        (if @(rf/subscribe [:twirly?])
          [spinner]
          (let [{:keys [results failure]} @(rf/subscribe [:results-or-failure])]

--- a/src/xt_fiddle/client.cljs
+++ b/src/xt_fiddle/client.cljs
@@ -196,7 +196,7 @@
          (for [k all-keys]
            ^{:key k}
            [:th {:class "text-left p-4"}
-            k])]]
+            (-> k symbol str)])]]
        [:tbody
         (for [[i row] (map-indexed vector results)]
           ^{:key i}

--- a/src/xt_fiddle/client.cljs
+++ b/src/xt_fiddle/client.cljs
@@ -205,7 +205,8 @@
              ^{:key k}
              [:td {:class "text-left p-4"}
               (let [value (get row k)]
-                (if (map? value)
+                (if (and (not (string? value))
+                         (seqable? value))
                   (case type
                     :xtql [highlight-code {:language "clojure"}
                            (pr-str value)]


### PR DESCRIPTION
- Editors no longer [overflow](https://fiddle.xtdb.com/?type=xtql&txs=WzpwdXQtZG9jcyA6ZG9jcyB7Onh0L2lkIDEgOmZvbyBbMSAyXX1dCls6cHV0LWRvY3MgOmRvY3Mgezp4dC9pZCAxIDpmb28gWzEgMl19XQpbOnB1dC1kb2NzIDpkb2NzIHs6eHQvaWQgMSA6Zm9vIFsxIDJdfV0KWzpwdXQtZG9jcyA6ZG9jcyB7Onh0L2lkIDEgOmZvbyBbMSAyXX1dCls6cHV0LWRvY3MgOmRvY3Mgezp4dC9pZCAxIDpmb28gWzEgMl19XQpbOnB1dC1kb2NzIDpkb2NzIHs6eHQvaWQgMSA6Zm9vIFsxIDJdfV0KWzpwdXQtZG9jcyA6ZG9jcyB7Onh0L2lkIDEgOmZvbyBbMSAyXX1dCls6cHV0LWRvY3MgOmRvY3Mgezp4dC9pZCAxIDpmb28gWzEgMl19XQpbOnB1dC1kb2NzIDpkb2NzIHs6eHQvaWQgMSA6Zm9vIFsxIDJdfV0KWzpwdXQtZG9jcyA6ZG9jcyB7Onh0L2lkIDEgOmZvbyBbMSAyXX1dCls6cHV0LWRvY3MgOmRvY3Mgezp4dC9pZCAxIDpmb28gWzEgMl19XQpbOnB1dC1kb2NzIDpkb2NzIHs6eHQvaWQgMSA6Zm9vIFsxIDJdfV0KWzpwdXQtZG9jcyA6ZG9jcyB7Onh0L2lkIDEgOmZvbyBbMSAyXX1dCls6cHV0LWRvY3MgOmRvY3Mgezp4dC9pZCAxIDpmb28gWzEgMl19XQpbOnB1dC1kb2NzIDpkb2NzIHs6eHQvaWQgMSA6Zm9vIFsxIDJdfV0KWzpwdXQtZG9jcyA6ZG9jcyB7Onh0L2lkIDEgOmZvbyBbMSAyXX1dCls6cHV0LWRvY3MgOmRvY3Mgezp4dC9pZCAxIDpmb28gWzEgMl19XQpbOnB1dC1kb2NzIDpkb2NzIHs6eHQvaWQgMSA6Zm9vIFsxIDJdfV0KWzpwdXQtZG9jcyA6ZG9jcyB7Onh0L2lkIDEgOmZvbyBbMSAyXX1dCls6cHV0LWRvY3MgOmRvY3Mgezp4dC9pZCAxIDpmb28gWzEgMl19XQpbOnB1dC1kb2NzIDpkb2NzIHs6eHQvaWQgMSA6Zm9vIFsxIDJdfV0KWzpwdXQtZG9jcyA6ZG9jcyB7Onh0L2lkIDEgOmZvbyBbMSAyXX1dCls6cHV0LWRvY3MgOmRvY3Mgezp4dC9pZCAxIDpmb28gWzEgMl19XQo%3D&query=KGZyb20gOmRvY3MgW3h0L2lkIGZvb10p)
- The prefix from columns like `:xt/id` are no longer [stripped](https://fiddle.xtdb.com/?type=xtql&txs=WzpwdXQtZG9jcyA6ZG9jcyB7Onh0L2lkIDEgOmZvbyAiYmFyIn1d&query=KGZyb20gOmRvY3MgW3h0L2lkIGZvb10p)
- The table renderer no longer [errors](https://fiddle.xtdb.com/?type=xtql&txs=WzpwdXQtZG9jcyA6ZG9jcyB7Onh0L2lkIDEgOmZvbyBbMSAyXX1d&query=KGZyb20gOmRvY3MgW3h0L2lkIGZvb10p) when given a vector value