### PR TITLE
Share button copies to clipboard

### DIFF
--- a/src/xt_fiddle/client.cljs
+++ b/src/xt_fiddle/client.cljs
@@ -154,10 +154,11 @@
   [:header {:class "bg-gray-200 py-2 px-4"}
    [:div {:class "container mx-auto flex flex-col md:flex-row items-center gap-1"}
     [:div {:class "w-full flex flex-row items-center gap-4"}
-     [:div {:class "flex flex-row items-center gap-1"}
-      [:img {:class "h-8"
-             :src "/public/images/xtdb-full-logo.svg"}]
-      [title "Fiddle"]]
+     [:a {:href "/"}
+      [:div {:class "flex flex-row items-center gap-1"}
+       [:img {:class "h-8"
+              :src "/public/images/xtdb-full-logo.svg"}]
+       [title "Fiddle"]]]
      [:span {:class "text-sm text-gray-400"}
       @(rf/subscribe [:version])]]
     [:div {:class "max-md:hidden flex-grow"}]

--- a/src/xt_fiddle/client.cljs
+++ b/src/xt_fiddle/client.cljs
@@ -150,6 +150,21 @@
     "Run"
     [:> PlayIcon {:class "h-5 w-5"}]]])
 
+(defn copy-button []
+  (let [copy-tick @(rf/subscribe [:copy-tick])]
+    [:div {:class (str "p-2 flex flex-row gap-1 items-center select-none"
+                       (when-not copy-tick
+                         " hover:bg-gray-300 cursor-pointer"))
+           :disabled copy-tick
+           :on-click #(rf/dispatch-sync [:copy-url])}
+     (if-not copy-tick
+       [:<>
+        "Copy URL"
+        [:> BookmarkIcon {:class "h-5 w-5"}]]
+       [:<>
+        "Copied!"
+        [:> CheckCircleIcon {:class "h-5 w-5"}]])]))
+
 (defn header []
   [:header {:class "bg-gray-200 py-2 px-4"}
    [:div {:class "container mx-auto flex flex-col md:flex-row items-center gap-1"}
@@ -165,19 +180,7 @@
     [:div {:class "w-full flex flex-row items-center gap-1 md:justify-end"}
      [language-dropdown]
      [:div {:class "md:hidden flex-grow"}]
-     (let [copy-tick @(rf/subscribe [:copy-tick])]
-       [:div {:class (str "p-2 flex flex-row gap-1 items-center select-none"
-                          (when-not copy-tick
-                            " hover:bg-gray-300 cursor-pointer"))
-              :disabled copy-tick
-              :on-click #(rf/dispatch-sync [:copy-url])}
-        (if-not copy-tick
-          [:<>
-           "Copy URL"
-           [:> BookmarkIcon {:class "h-5 w-5"}]]
-          [:<>
-           "Copied!"
-           [:> CheckCircleIcon {:class "h-5 w-5"}]])])
+     [copy-button]
      [run-button]]]])
 
 (defn reset-system-time-button [id]

--- a/src/xt_fiddle/client.cljs
+++ b/src/xt_fiddle/client.cljs
@@ -19,21 +19,21 @@
                                                    CheckCircleIcon]]))
 
 (rf/reg-event-db
-  :share-hide-tick
+  :hide-copy-tick
   (fn [db _]
-    (dissoc db :share-show-tick)))
+    (dissoc db :copy-tick)))
 
 (rf/reg-event-fx
-  :share
+  :copy-url
   [(rf/inject-cofx ::href/get)]
   (fn [{:keys [db href]} _]
     {::clipboard/set {:text href}
-     :db (assoc db :share-show-tick true)
-     :dispatch-later {:ms 800 :dispatch [:share-hide-tick]}}))
+     :db (assoc db :copy-tick true)
+     :dispatch-later {:ms 800 :dispatch [:hide-copy-tick]}}))
 
 (rf/reg-sub
-  :share-show-tick
-  :-> :share-show-tick)
+  :copy-tick
+  :-> :copy-tick)
 
 (rf/reg-event-fx
   :update-url
@@ -165,18 +165,18 @@
     [:div {:class "w-full flex flex-row items-center gap-1 md:justify-end"}
      [language-dropdown]
      [:div {:class "md:hidden flex-grow"}]
-     (let [share-show-tick @(rf/subscribe [:share-show-tick])]
-       [:div {:class (str "p-2 flex flex-row gap-1 items-center"
-                          (when-not share-show-tick
+     (let [copy-tick @(rf/subscribe [:copy-tick])]
+       [:div {:class (str "p-2 flex flex-row gap-1 items-center select-none"
+                          (when-not copy-tick
                             " hover:bg-gray-300 cursor-pointer"))
-              :disabled share-show-tick
-              :on-click #(rf/dispatch-sync [:share])}
-        (if-not share-show-tick
+              :disabled copy-tick
+              :on-click #(rf/dispatch-sync [:copy-url])}
+        (if-not copy-tick
           [:<>
-           "Save as URL"
+           "Copy URL"
            [:> BookmarkIcon {:class "h-5 w-5"}]]
           [:<>
-           "Saved!"
+           "Copied!"
            [:> CheckCircleIcon {:class "h-5 w-5"}]])])
      [run-button]]]])
 

--- a/src/xt_fiddle/clipboard.cljs
+++ b/src/xt_fiddle/clipboard.cljs
@@ -1,0 +1,10 @@
+(ns xt-fiddle.clipboard
+  (:require [re-frame.core :as rf]))
+
+(rf/reg-fx ::set
+  (fn [{:keys [text on-success on-failure]}]
+    (-> (js/navigator.clipboard.writeText text)
+        (.then #(when on-success
+                  (rf/dispatch on-success)))
+        (.catch #(when on-failure
+                   (rf/dispatch (conj on-failure %)))))))

--- a/src/xt_fiddle/href.cljs
+++ b/src/xt_fiddle/href.cljs
@@ -1,0 +1,6 @@
+(ns xt-fiddle.href
+  (:require [re-frame.core :as rf]))
+
+(rf/reg-cofx ::get
+  (fn [cofx _]
+    (assoc cofx :href js/window.location.href)))

--- a/src/xt_fiddle/query_params.cljs
+++ b/src/xt_fiddle/query_params.cljs
@@ -18,6 +18,10 @@
     (.toString search-params)))
 
 (defn set-query-params [params]
-  (set! (.-search js/window.location) (->query-string params)))
+  (let [url (js/URL. js/window.location.href)]
+    (set! (.-search url) (->query-string params))
+    ;; We replace the history instead of pushing a new state
+    ;; because it's a pain to hook up the back and forward buttons
+    (js/window.history.replaceState "" "" (.toString url))))
 
 (rf/reg-fx ::set set-query-params)


### PR DESCRIPTION
- Update the url live while the user types
- The share button now copies the url to the clipboard
- The share button now has feedback
- Reset the fiddle when clicking the logo

https://github.com/xtdb/xt-fiddle/assets/8889986/2ce0e817-59e0-4239-b966-b2691afbbeb2

Fixes #35 #30