### PR TITLE
Joa/test

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,33 @@
+name: Unit tests
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+
+  clojure:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Prepare java
+        uses: actions/setup-java@v4.2.1
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup Clojure
+        uses: DeLaGuardo/setup-clojure@12.5
+        with:
+          cli: 1.11.3.1463
+
+      - name: Test Clojure
+        run: clojure -M:test

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+clojure -M:test "$@"

--- a/deps.edn
+++ b/deps.edn
@@ -58,8 +58,9 @@
               "-Dio.netty.tryReflectionSetAccessible=true"]}
 
   :test
-  {:extra-paths ["test"]
-   :extra-deps  {lambdaisland/kaocha {:mvn/version "1.0.632"}}}
+  {:extra-paths ["test/clj"]
+   :extra-deps  {lambdaisland/kaocha {:mvn/version "1.91.1392"}}
+   :main-opts ["-m" "kaocha.runner"]}
 
   :build {:extra-deps {io.github.clojure/tools.build {:git/tag "v0.8.4" :git/sha "8c3cd69"}}
           :ns-default build}}

--- a/src/clj/xt_play/transactions.clj
+++ b/src/clj/xt_play/transactions.clj
@@ -3,12 +3,8 @@
             [clojure.data.json :as json]
             [clojure.instant :refer [read-instant-date]]
             [clojure.tools.logging :as log]
-            [next.jdbc :as jdbc]
-            [next.jdbc.result-set :as jdbc-res]
-            [xt-play.config :as config]
             [xt-play.util :as util]
-            [xtdb.api :as xt]
-            [xtdb.node :as xtn]))
+            [xt-play.xtdb :as xtdb]))
 
 (defn- encode-txs [tx-type txs]
   (case (keyword tx-type)
@@ -37,25 +33,6 @@
 (defn format-system-time [s]
   (when s (read-instant-date s)))
 
-(defn- run!-tx [node tx-type tx-batches query]
-  (let [tx-batches (->> tx-batches
-                        (map #(update % :system-time format-system-time))
-                        (map #(update % :txs (partial encode-txs tx-type))))]
-    (doseq [{:keys [system-time txs] :as batch} tx-batches]
-      (log/info tx-type "running batch: " batch)
-      (let [tx (xt/submit-tx node txs {:system-time system-time})
-            results (xt/q node '(from :xt/txs [{:xt/id $tx-id} xt/error])
-                          {:args {:tx-id (:tx-id tx)}})]
-        ;; If any transaction fails, throw the error
-        (log/info tx-type "batch complete:" tx ", results:" results)
-        (when-let [error (-> results first :xt/error)]
-          (throw error)))))
-  (log/info tx-type "running query:" query)
-  (let [res (xt/q node query (when (string? query)
-                               {:key-fn :snake-case-string}))]
-    (log/info tx-type "XTDB query response:" res)
-    res))
-
 (defn- PGobject->clj [v]
   (if (= org.postgresql.util.PGobject (type v))
     (json/read-str (.getValue v) :key-fn keyword)
@@ -70,16 +47,30 @@
      (mapv PGobject->clj row))
    result))
 
+(defn- run!-tx [node tx-type tx-batches query]
+  (let [tx-batches (->> tx-batches
+                        (map #(update % :system-time format-system-time))
+                        (map #(update % :txs (partial encode-txs tx-type))))]
+    (doseq [{:keys [system-time txs] :as batch} tx-batches]
+      (log/info tx-type "running batch: " batch)
+      (xtdb/submit! node txs {:system-time system-time})))
+  (log/info tx-type "running query:" query)
+  (let [res (xtdb/query node query)]
+    (def res res)
+    (log/info tx-type "XTDB query response:" res)
+    res))
+
 (defn- run!-with-jdbc-conn [tx-batches query]
-  (with-open [conn (jdbc/get-connection config/db)]
-    (doseq [tx (prepare-statements tx-batches)
-            statement tx]
-      (log/info "beta executing statement:" statement)
-      (jdbc/execute! conn statement))
-    (log/info "beta running query:" query)
-    (let [res (jdbc/execute! conn [query] {:builder-fn jdbc-res/as-arrays})]
-      (log/info "beta query resoponse" res)
-      (parse-result res))))
+  (xtdb/with-jdbc
+    (fn [conn]
+      (doseq [tx (prepare-statements tx-batches)
+              statement tx]
+        (log/info "beta executing statement:" statement)
+        (xtdb/jdbc-execute! conn statement))
+      (log/info "beta running query:" query)
+      (let [res (xtdb/jdbc-execute! conn [query])]
+        (log/info "beta query resoponse" res)
+        (parse-result res)))))
 
 (defn run!!
   "Given transaction batches, a query and the type of transaction to
@@ -87,35 +78,20 @@
   returning the last query response in column format."
   [{:keys [tx-batches query tx-type]}]
   (let [query (if (= "xtql" tx-type) (util/read-edn query) query)]
-    (try
-      (with-open [node (xtn/start-node {})]
+    (xtdb/with-xtdb
+      (fn [node]
         (if (= "sql-beta" tx-type)
           (run!-with-jdbc-conn tx-batches query)
-          (util/map-results->rows
-           (run!-tx node tx-type tx-batches query))))
-      (catch Exception e
-        (log/warn :submit-error {:e e})
-        (throw e)))))
+          (let [res (run!-tx node tx-type tx-batches query)]
+            (util/map-results->rows res)))))))
 
 (defn docs-run!!
   "Given transaction batches and a query from the docs, will return the query
   response in map format. Assumes tx type is sql."
   [{:keys [tx-batches query]}]
-  (try
-    (with-open [node (xtn/start-node {})]
+  (xtdb/with-xtdb
+    (fn [node]
       (run!-tx node "sql"
                (mapv #(update % :txs util/read-edn) tx-batches)
-               (util/read-edn query)))
-    (catch Exception e
-      (log/warn :submit-error {:e e})
-      (throw e))))
+               (util/read-edn query)))))
 
-(comment
-  (with-open [node (xtn/start-node {})]
-    (doseq [st [#inst "2022" #inst "2021"]]
-      (let [tx (xt/submit-tx node [] {:system-time st})
-            results (xt/q node '(from :xt/txs [{:xt/id $tx-id} xt/error])
-                          {:basis {:at-tx tx}
-                           :args {:tx-id (:tx-id tx)}})]
-        (when-let [error (-> results first :xt/error)]
-          (throw (ex-info "Transaction error" {:error error})))))))

--- a/src/clj/xt_play/xtdb.clj
+++ b/src/clj/xt_play/xtdb.clj
@@ -1,0 +1,48 @@
+(ns xt-play.xtdb
+  (:require [clojure.tools.logging :as log]
+            [next.jdbc :as jdbc]
+            [next.jdbc.result-set :as jdbc-res]
+            [xt-play.config :as config]
+            [xtdb.api :as xt]
+            [xtdb.node :as xtn]))
+
+(defn with-xtdb [f]
+  (try
+    (with-open [node (xtn/start-node {})]
+      (f node))
+    (catch Exception e
+      (log/warn :submit-error {:e e})
+      (throw e))))
+
+(defn submit! [node txs opts]
+  (log/info :submit-tx txs opts)
+  (let [tx (xt/submit-tx node txs opts)
+        results (xt/q node '(from :xt/txs [{:xt/id $tx-id} xt/error])
+                      {:args {:tx-id (:tx-id tx)}})]
+    (log/info :submit-tx results)
+    ;; If any transaction fails, throw the error
+    (when-let [error (-> results first :xt/error)]
+      (throw error))))
+
+(defn query [node q]
+  (log/info :query q)
+  (xt/q node q (when (string? q) {:key-fn :snake-case-string})))
+
+(defn with-jdbc [f]
+  (with-open [conn (jdbc/get-connection config/db)]
+    (f conn)))
+
+(defn jdbc-execute! 
+  [conn statement]
+  (log/info :jdbc-execute! statement)
+  (jdbc/execute! conn statement {:builder-fn jdbc-res/as-arrays}))
+
+(comment
+  (with-open [node (xtn/start-node {})]
+    (doseq [st [#inst "2022" #inst "2021"]]
+      (let [tx (xt/submit-tx node [] {:system-time st})
+            results (xt/q node '(from :xt/txs [{:xt/id $tx-id} xt/error])
+                          {:basis {:at-tx tx}
+                           :args {:tx-id (:tx-id tx)}})]
+        (when-let [error (-> results first :xt/error)]
+          (throw (ex-info "Transaction error" {:error error})))))))

--- a/test/clj/xt_play/handler_test.clj
+++ b/test/clj/xt_play/handler_test.clj
@@ -1,196 +1,195 @@
 (ns xt-play.handler-test
   (:require [clojure.edn :as edn]
+            [clojure.string :as str]
             [clojure.test :as t]
             [clojure.data.json :as json]
-            [next.jdbc :as jdbc]
             [xt-play.handler :as h]
-            [xtdb.api :as xt]))
-
+            [xt-play.xtdb-stubs :refer [with-stubs db clean-db mock-resp reset-resp]]))
 ;; todo:
 ;; [ ] test unhappy paths
 ;; [ ] test wider range of scenarios / formats
-;; [ ] test to pipeline
+;; [x] test to pipeline
 ;; [ ] assert format from client
+;; [x] stub xtdb
+;; [x] integration tests with xtdb
+
 
 (defn- t-file [path]
   (edn/read-string (slurp (format "test-resources/%s.edn" path))))
 
 (t/deftest run-handler-test
-  (t/testing "xtql example returns expected results"
-    (t/is (= {:status 200, :body [[:foo :xt/id] ["bar" 1]]}
-             (h/run-handler (t-file "xtql-example-request")))))
+  (with-stubs
+    #(do
+       (t/testing "xtql example sends expected payload to xtdb"
+         (clean-db)
+         (h/run-handler (t-file "xtql-example-request"))
+         (let [[txs query] @db]
+           (t/is (= 2 (count @db)))
+           (t/is (= [[:put-docs :docs {:xt/id 1, :foo "bar"}]]
+                    txs))
+           (t/is (= '(from :docs [xt/id foo])
+                    query))))
 
-  (t/testing "sql example returns expected results"
-    (t/is (= {:status 200,
-              :body
-              [["_id" "col1" "col2"]
-               [2 "bar" " baz"]
-               [1 "foo" nil]]}
-             (h/run-handler (t-file "sql-example-request")))))
+       (t/testing "sql example sends expected payload to xtdb"
+         (clean-db)
+         (h/run-handler (t-file "sql-example-request"))
+         (let [[txs query] @db]
+           (t/is (= 2 (count @db)))
+           (t/is (= [[:sql "INSERT INTO docs (_id, col1) VALUES (1, 'foo')"]          
+                     [:sql "
+INSERT INTO docs RECORDS {_id: 2, col1: 'bar', col2:' baz'}"]]
+                  txs))
+           (t/is (= "SELECT * FROM docs"
+                  query))
+           (t/is (not (str/includes? (first txs) ";")))))
 
-  (t/testing "beta sql example returns expected results"
-    (t/is (= {:status 200,
-              :body
-              [[:_id :col1 :col2]
-               [2 "bar" " baz"]
-               [1 "foo" nil]]}
-             (h/run-handler (t-file "beta-sql-example-request"))))))
+       (t/testing "beta sql example sends expected payload to xtdb"
+         (clean-db)
+         (h/run-handler (t-file "beta-sql-example-request"))
+         (let [[txs query] @db]
+           (t/is (= 2 (count @db)))
+           (t/is (= ["INSERT INTO docs (_id, col1) VALUES (1, 'foo');
+INSERT INTO docs RECORDS {_id: 2, col1: 'bar', col2:' baz'};"]
+                  txs))
+           (t/is (= ["SELECT * FROM docs"]
+                  query))
+           (t/is (str/includes? (first txs) ";")))))))
 
 (t/deftest run-handler-multi-transactions-test
-  (t/testing "multiple transactions in xtql"
-    (t/is (= {:status 200, :body [[:foo :xt/id]
-                                  ["baz" 2]
-                                  ["bar" 1]]}
-             (h/run-handler
+  (with-stubs
+    #(do
+       (t/testing "multiple transactions in xtql"
+         (clean-db)
+         (h/run-handler (assoc-in
+                         (t-file "xtql-example-request")
+                         [:parameters :body :tx-batches]
+                         [{:txs "[:put-docs :docs {:xt/id 1 :foo \"bar\"}]",
+                           :system-time "2024-12-01T00:00:00.000Z"}
+                          {:txs "[:put-docs :docs {:xt/id 2 :foo \"baz\"}]",
+                           :system-time nil}]))
+         (let [[tx1 tx2 query] @db]
+           (t/is (= 3 (count @db)))
+           (t/is (= [[:put-docs :docs {:xt/id 1, :foo "bar"}]]
+                    tx1))
+           (t/is (= [[:put-docs :docs {:xt/id 2, :foo "baz"}]]
+                    tx2))
+           (t/is (= '(from :docs [xt/id foo])
+                    query))))
+
+       (t/testing "multiple transacions on sql"
+         (clean-db)
+         (h/run-handler
+          (-> (t-file "sql-example-request")
               (assoc-in
-               (t-file "xtql-example-request")
                [:parameters :body :tx-batches]
-               [{:txs "[:put-docs :docs {:xt/id 1 :foo \"bar\"}]",
+               [{:txs "INSERT INTO docs (_id, col1) VALUES (1, 'foo');",
                  :system-time "2024-12-01T00:00:00.000Z"}
-                {:txs "[:put-docs :docs {:xt/id 2 :foo \"baz\"}]",
-                 :system-time nil}])))))
-
-  (t/testing "multiple transacions on sql"
-    (t/is (= {:status 200,
-              :body
-              [["_id" "col1" "col2" "_valid_from"]
-               [2 "bar" " baz" #time/zoned-date-time "2024-12-02T00:00Z[UTC]"]
-               [1 "foo" nil #time/zoned-date-time "2024-12-01T00:00Z[UTC]"]]}
-             (h/run-handler
-              (-> (t-file "sql-example-request")
-                  (assoc-in
-                   [:parameters :body :tx-batches]
-                   [{:txs "INSERT INTO docs (_id, col1) VALUES (1, 'foo');",
-                     :system-time "2024-12-01T00:00:00.000Z"}
-                    {:txs "INSERT INTO docs RECORDS {_id: 2, col1: 'bar', col2:' baz'};",
-                     :system-time "2024-12-02T00:00:00.000Z"}])
-                  (assoc-in
-                   [:parameters :body :query]
-                   "SELECT *, _valid_from FROM docs"))))))
-
-  (t/testing "beta sql can run multiple txs"
-    (t/is (= {:status 200,
-              :body
-              [[:_id :col1 :col2 :_valid_from]
-               [2 "bar" " baz" #inst "2024-12-02T00:00:00.000000000-00:00"]
-               [1 "foo" nil #inst "2024-12-01T00:00:00.000000000-00:00"]]}
-             (h/run-handler
-              (-> (t-file "beta-sql-example-request")
-                  (assoc-in
-                   [:parameters :body :tx-batches]
-                   [{:txs "INSERT INTO docs (_id, col1) VALUES (1, 'foo');",
-                     :system-time "2024-12-01T00:00:00.000Z"}
-                    {:txs "INSERT INTO docs RECORDS {_id: 2, col1: 'bar', col2:' baz'};",
-                     :system-time "2024-12-02T00:00:00.000Z"}])
-                  (assoc-in
-                   [:parameters :body :query]
-                   "SELECT *, _valid_from FROM docs")))))))
-
-(t/deftest beta-sql-run-features
-  (t/testing "Column order is maintained"
-    (t/is (= {:status 200,
-              :body [[:_id :a :b :c :d :e :f :g :h :j]
-                     [1 2 3 4 5 6 7 8 9 10]]}
-             (h/run-handler
+                {:txs "INSERT INTO docs RECORDS {_id: 2, col1: 'bar', col2:' baz'};",
+                 :system-time "2024-12-02T00:00:00.000Z"}])
               (assoc-in
-               (t-file "beta-sql-example-request")
-               [:parameters :body :tx-batches]
-               [{:txs "INSERT INTO docs RECORDS {_id: 1, a: 2, b: 3, c: 4, d: 5, e: 6, f: 7, g: 8, h: 9, j: 10}"
-                 :system-time nil}])))))
-
-  (t/testing "execute payload is not mutated"
-    (let [txs (atom [])]
-      (with-redefs [jdbc/execute! (fn [_conn statement & args]
-                                    (swap! txs conj statement))]
-        (h/run-handler (t-file "beta-sql-example-request"))
-        (t/is
-         (= [[(str "INSERT INTO docs (_id, col1) VALUES (1, 'foo');\n"
-                   "INSERT INTO docs RECORDS {_id: 2, col1: 'bar', col2:' baz'};")]
-             ["SELECT * FROM docs"]]
-            @txs)))))
-
-  (t/testing "xt submit-tx sql payload is reformatted"
-    (let [txs (atom [])]
-      (def txs txs)
-      (with-redefs [xt/submit-tx (fn [_node tx & args]
-                                   (swap! txs conj tx))]
-        (h/run-handler (t-file "sql-example-request"))
-        (t/is
-         (= [[[:sql "INSERT INTO docs (_id, col1) VALUES (1, 'foo')"]
-              [:sql "\nINSERT INTO docs RECORDS {_id: 2, col1: 'bar', col2:' baz'}"]]]
-            @txs))))))
-
-(t/deftest sql-says-carol-is-red-test
-  (t/testing "XTDB docs example for sql https://docs.xtdb.com/quickstart/sql-overview.html"
-    (t/is (= {:status 200,
-              :body
-              [["name" "favorite_color" "_valid_from" "_system_from"]
-               ["carol"
-                "red"
-                #time/zoned-date-time "2023-09-01T00:00Z[UTC]"
-                #time/zoned-date-time "2024-01-08T00:00Z[UTC]"]]}
-             (h/run-handler (t-file "sql-multi-transaction")))))
-
-  (t/testing "Bob still likes fishing - don't determine columns based on the first row"
-    (t/is (= {:status 200,
-              :body
-              [["_id" "favorite_color" "name" "likes"]
-               [2 "red" "carol" nil]
-               [9 nil "bob" ["fishing" 3.14 {"nested" "data"}]]]}
-             (h/run-handler
-              (assoc-in
-               (t-file "sql-multi-transaction")
                [:parameters :body :query]
-               "SELECT * FROM people"))))))
+               "SELECT *, _valid_from FROM docs")))
+         (let [[tx1 tx2 query] @db]
+           (t/is (= 3 (count @db)))
+           (t/is (= [[:sql "INSERT INTO docs (_id, col1) VALUES (1, 'foo')"]]
+                    tx1))
+           (t/is (= [[:sql "INSERT INTO docs RECORDS {_id: 2, col1: 'bar', col2:' baz'}"]]
+                    tx2))
+           (t/is (= "SELECT *, _valid_from FROM docs"
+                    query)))
+         )
 
-(t/deftest beta-sql-says-carol-is-red-test
-  (t/testing "XTDB docs example for sql https://docs.xtdb.com/quickstart/sql-overview.html"
-    (t/is (= {:status 200,
-              :body
-              [[:name :favorite_color :_valid_from :_system_from]
-               ["carol"
-                "red"
-                #inst "2023-08-31T23:00:00.000000000-00:00"
-                #inst "2024-01-08T00:00:00.000000000-00:00"]]}
-             (h/run-handler (assoc-in
-                             (t-file "sql-multi-transaction")
-                             [:parameters :body :tx-type]
-                             "sql-beta")))))
+       (t/testing "multiple transacions on beta sql"
+         (clean-db)
+         (h/run-handler
+          (-> (t-file "beta-sql-example-request")
+              (assoc-in
+               [:parameters :body :tx-batches]
+               [{:txs "INSERT INTO docs (_id, col1) VALUES (1, 'foo');",
+                 :system-time "2024-12-01T00:00:00.000Z"}
+                {:txs "INSERT INTO docs RECORDS {_id: 2, col1: 'bar', col2:' baz'};",
+                 :system-time "2024-12-02T00:00:00.000Z"}])
+              (assoc-in
+               [:parameters :body :query]
+               "SELECT *, _valid_from FROM docs")))
 
-  (t/testing "Bob still likes fishing - don't determine columns based on the first row"
-    (t/is (= {:status 200,
-             :body
-             [[:_id :favorite_color :info :likes :name]
-              [2 "red" nil nil "carol"]
-              [9 nil nil ["fishing" 3.14 {:nested "data"}] "bob"]]}
-             (h/run-handler
-              (->  (t-file "sql-multi-transaction")
-                   (assoc-in [:parameters :body :query] "SELECT * FROM people")
-                   (assoc-in [:parameters :body :tx-type] "sql-beta")))))))
+         (t/is (= 7 (count @db)))
+         (t/is (= [["BEGIN AT SYSTEM_TIME TIMESTAMP '2024-12-01T00:00:00.000Z'"]
+                   ["INSERT INTO docs (_id, col1) VALUES (1, 'foo');"]
+                   ["COMMIT"]
+                   ["BEGIN AT SYSTEM_TIME TIMESTAMP '2024-12-02T00:00:00.000Z'"]
+                   ["INSERT INTO docs RECORDS {_id: 2, col1: 'bar', col2:' baz'};"]
+                   ["COMMIT"]
+                   ["SELECT *, _valid_from FROM docs"]]
+                  @db))))))
+
+(t/deftest do-not-drop-columns
+  (with-stubs
+    #(do
+       (t/testing "Bob still likes fishing - don't determine columns based on the first row"
+         (mock-resp [{"_id" 2, "favorite_color" "red", "name" "carol"}
+                     {"_id" 9, "likes" ["fishing" 3.14 {"nested" "data"}], "name" "bob"}])
+         (t/is (= {:status 200,
+                   :body
+                   [["_id" "favorite_color" "name" "likes"]
+                    [2 "red" "carol" nil]
+                    [9 nil "bob" ["fishing" 3.14 {"nested" "data"}]]]}
+                  (h/run-handler
+                   (assoc-in
+                    (t-file "sql-multi-transaction")
+                    [:parameters :body :query]
+                    "SELECT * FROM people")))))
+       (reset-resp))))
 
 (def docs-json
- "{\"tx-batches\":[{\"txs\":\"[[:sql \\\"INSERT INTO product (_id, name, price) VALUES\\\\n(1, 'An Electric Bicycle', 400)\\\"]]\",\"system-time\":\"2024-01-01\"},{\"txs\":\"[[:sql \\\"UPDATE product SET price = 405 WHERE _id = 1\\\"]]\",\"system-time\":\"2024-01-05\"},{\"txs\":\"[[:sql \\\"UPDATE product SET price = 350 WHERE _id = 1\\\"]]\",\"system-time\":\"2024-01-10\"}],\"query\":\"\\\"SELECT *, _valid_from\\\\nFROM product\\\\nFOR VALID_TIME ALL -- i.e. \\\\\\\"show me all versions\\\\\\\"\\\\nFOR SYSTEM_TIME AS OF DATE '2024-01-31' -- \\\\\\\"...as observed at month end\\\\\\\"\\\"\"}"
-)
+  "{\"tx-batches\":[{\"txs\":\"[[:sql \\\"INSERT INTO product (_id, name, price) VALUES\\\\n(1, 'An Electric Bicycle', 400)\\\"]]\",\"system-time\":\"2024-01-01\"},{\"txs\":\"[[:sql \\\"UPDATE product SET price = 405 WHERE _id = 1\\\"]]\",\"system-time\":\"2024-01-05\"},{\"txs\":\"[[:sql \\\"UPDATE product SET price = 350 WHERE _id = 1\\\"]]\",\"system-time\":\"2024-01-10\"}],\"query\":\"\\\"SELECT *, _valid_from\\\\nFROM product\\\\nFOR VALID_TIME ALL -- i.e. \\\\\\\"show me all versions\\\\\\\"\\\\nFOR SYSTEM_TIME AS OF DATE '2024-01-31' -- \\\\\\\"...as observed at month end\\\\\\\"\\\"\"}"
+  )
 
 (t/deftest docs-run
-  (let [response (h/docs-run-handler {:parameters {:body (json/read-str docs-json :key-fn keyword)}})]
-    (t/testing "docs run returns map results"
-      (t/is
-       (every? map? (:body response))))
+  (with-stubs
+    #(do
+       (clean-db)
+       (mock-resp [{"_id" 1,
+                    "name" "An Electric Bicycle",
+                    "price" 350,
+                    "_valid_from" #time/zoned-date-time "2024-01-10T00:00Z[UTC]"}
+                   {"_id" 1,
+                    "name" "An Electric Bicycle",
+                    "price" 405,
+                    "_valid_from" #time/zoned-date-time "2024-01-05T00:00Z[UTC]"}
+                   {"_id" 1,
+                    "name" "An Electric Bicycle",
+                    "price" 400,
+                    "_valid_from" #time/zoned-date-time "2024-01-01T00:00Z[UTC]"}])
+       
+       (let [response (h/docs-run-handler {:parameters {:body (json/read-str docs-json :key-fn keyword)}})
+             txs (drop-last @db)
+             query (last @db)]
 
-    (t/testing "can handle \" strings from docs"
-      (t/is (= {:status 200,
-                :body
-                [{"_id" 1,
-                  "name" "An Electric Bicycle",
-                  "price" 350,
-                  "_valid_from" #time/zoned-date-time "2024-01-10T00:00Z[UTC]"}
-                 {"_id" 1,
-                  "name" "An Electric Bicycle",
-                  "price" 405,
-                  "_valid_from" #time/zoned-date-time "2024-01-05T00:00Z[UTC]"}
-                 {"_id" 1,
-                  "name" "An Electric Bicycle",
-                  "price" 400,
-                  "_valid_from" #time/zoned-date-time "2024-01-01T00:00Z[UTC]"}]}
-               response)))))
+         (t/is (= [[[:sql "INSERT INTO product (_id, name, price) VALUES\n(1, 'An Electric Bicycle', 400)"]]
+                   [[:sql "UPDATE product SET price = 405 WHERE _id = 1"]]
+                   [[:sql "UPDATE product SET price = 350 WHERE _id = 1"]]]
+                  txs))
+
+         (t/is (= "SELECT *, _valid_from\nFROM product\nFOR VALID_TIME ALL -- i.e. \"show me all versions\"\nFOR SYSTEM_TIME AS OF DATE '2024-01-31' -- \"...as observed at month end\""
+                  query))
+         
+         (t/testing "docs run returns map results"
+           (t/is (every? map? (:body response))))
+
+         (t/testing "can handle \" strings from docs"
+           (t/is (= {:status 200,
+                     :body
+                     [{"_id" 1,
+                       "name" "An Electric Bicycle",
+                       "price" 350,
+                       "_valid_from" #time/zoned-date-time "2024-01-10T00:00Z[UTC]"}
+                      {"_id" 1,
+                       "name" "An Electric Bicycle",
+                       "price" 405,
+                       "_valid_from" #time/zoned-date-time "2024-01-05T00:00Z[UTC]"}
+                      {"_id" 1,
+                       "name" "An Electric Bicycle",
+                       "price" 400,
+                       "_valid_from" #time/zoned-date-time "2024-01-01T00:00Z[UTC]"}]}
+                    response)))))))

--- a/test/clj/xt_play/integration_test.clj
+++ b/test/clj/xt_play/integration_test.clj
@@ -1,0 +1,193 @@
+(ns ^:integration xt-play.integration-test
+  (:require [clojure.edn :as edn]
+            [clojure.test :as t]
+            [clojure.data.json :as json]
+            [next.jdbc :as jdbc]
+            [xt-play.handler :as h]
+            [xtdb.api :as xt]))
+
+;; todo - this should be purely testing xt responses, not the handler.
+;; can share the expected tx data from the results to keep in sync with changes
+
+(defn- t-file [path]
+  (edn/read-string (slurp (format "test-resources/%s.edn" path))))
+
+(t/deftest run-handler-test
+  (t/testing "xtql example returns expected results"
+    (t/is (= {:status 200, :body [[:foo :xt/id] ["bar" 1]]}
+             (h/run-handler (t-file "xtql-example-request")))))
+
+  (t/testing "sql example returns expected results"
+    (t/is (= {:status 200,
+              :body
+              [["_id" "col1" "col2"]
+               [2 "bar" " baz"]
+               [1 "foo" nil]]}
+             (h/run-handler (t-file "sql-example-request")))))
+
+  (t/testing "beta sql example returns expected results"
+    (t/is (= {:status 200,
+              :body
+              [[:_id :col1 :col2]
+               [2 "bar" " baz"]
+               [1 "foo" nil]]}
+             (h/run-handler (t-file "beta-sql-example-request"))))))
+
+(t/deftest run-handler-multi-transactions-test
+  (t/testing "multiple transactions in xtql"
+    (t/is (= {:status 200, :body [[:foo :xt/id]
+                                  ["baz" 2]
+                                  ["bar" 1]]}
+             (h/run-handler
+              (assoc-in
+               (t-file "xtql-example-request")
+               [:parameters :body :tx-batches]
+               [{:txs "[:put-docs :docs {:xt/id 1 :foo \"bar\"}]",
+                 :system-time "2024-12-01T00:00:00.000Z"}
+                {:txs "[:put-docs :docs {:xt/id 2 :foo \"baz\"}]",
+                 :system-time nil}])))))
+
+  (t/testing "multiple transacions on sql"
+    (t/is (= {:status 200,
+              :body
+              [["_id" "col1" "col2" "_valid_from"]
+               [2 "bar" " baz" #time/zoned-date-time "2024-12-02T00:00Z[UTC]"]
+               [1 "foo" nil #time/zoned-date-time "2024-12-01T00:00Z[UTC]"]]}
+             (h/run-handler
+              (-> (t-file "sql-example-request")
+                  (assoc-in
+                   [:parameters :body :tx-batches]
+                   [{:txs "INSERT INTO docs (_id, col1) VALUES (1, 'foo');",
+                     :system-time "2024-12-01T00:00:00.000Z"}
+                    {:txs "INSERT INTO docs RECORDS {_id: 2, col1: 'bar', col2:' baz'};",
+                     :system-time "2024-12-02T00:00:00.000Z"}])
+                  (assoc-in
+                   [:parameters :body :query]
+                   "SELECT *, _valid_from FROM docs"))))))
+
+  (t/testing "beta sql can run multiple txs"
+    (t/is (= {:status 200,
+              :body
+              [[:_id :col1 :col2 :_valid_from]
+               [2 "bar" " baz" #inst "2024-12-02T00:00:00.000000000-00:00"]
+               [1 "foo" nil #inst "2024-12-01T00:00:00.000000000-00:00"]]}
+             (h/run-handler
+              (-> (t-file "beta-sql-example-request")
+                  (assoc-in
+                   [:parameters :body :tx-batches]
+                   [{:txs "INSERT INTO docs (_id, col1) VALUES (1, 'foo');",
+                     :system-time "2024-12-01T00:00:00.000Z"}
+                    {:txs "INSERT INTO docs RECORDS {_id: 2, col1: 'bar', col2:' baz'};",
+                     :system-time "2024-12-02T00:00:00.000Z"}])
+                  (assoc-in
+                   [:parameters :body :query]
+                   "SELECT *, _valid_from FROM docs")))))))
+
+(t/deftest beta-sql-run-features
+  (t/testing "Column order is maintained"
+    (t/is (= {:status 200,
+              :body [[:_id :a :b :c :d :e :f :g :h :j]
+                     [1 2 3 4 5 6 7 8 9 10]]}
+             (h/run-handler
+              (assoc-in
+               (t-file "beta-sql-example-request")
+               [:parameters :body :tx-batches]
+               [{:txs "INSERT INTO docs RECORDS {_id: 1, a: 2, b: 3, c: 4, d: 5, e: 6, f: 7, g: 8, h: 9, j: 10}"
+                 :system-time nil}])))))
+
+  (t/testing "execute payload is not mutated"
+    (let [txs (atom [])]
+      (with-redefs [jdbc/execute! (fn [_conn statement & args]
+                                    (swap! txs conj statement))]
+        (h/run-handler (t-file "beta-sql-example-request"))
+        (t/is
+         (= [[(str "INSERT INTO docs (_id, col1) VALUES (1, 'foo');\n"
+                   "INSERT INTO docs RECORDS {_id: 2, col1: 'bar', col2:' baz'};")]
+             ["SELECT * FROM docs"]]
+            @txs)))))
+
+  (t/testing "xt submit-tx sql payload is reformatted"
+    (let [txs (atom [])]
+      (def txs txs)
+      (with-redefs [xt/submit-tx (fn [_node tx & args]
+                                   (swap! txs conj tx))]
+        (h/run-handler (t-file "sql-example-request"))
+        (t/is
+         (= [[[:sql "INSERT INTO docs (_id, col1) VALUES (1, 'foo')"]
+              [:sql "\nINSERT INTO docs RECORDS {_id: 2, col1: 'bar', col2:' baz'}"]]]
+            @txs))))))
+
+(t/deftest sql-says-carol-is-red-test
+  (t/testing "XTDB docs example for sql https://docs.xtdb.com/quickstart/sql-overview.html"
+    (t/is (= {:status 200,
+              :body
+              [["name" "favorite_color" "_valid_from" "_system_from"]
+               ["carol"
+                "red"
+                #time/zoned-date-time "2023-09-01T00:00Z[UTC]"
+                #time/zoned-date-time "2024-01-08T00:00Z[UTC]"]]}
+             (h/run-handler (t-file "sql-multi-transaction")))))
+
+  (t/testing "Bob still likes fishing - don't determine columns based on the first row"
+    (t/is (= {:status 200,
+              :body
+              [["_id" "favorite_color" "name" "likes"]
+               [2 "red" "carol" nil]
+               [9 nil "bob" ["fishing" 3.14 {"nested" "data"}]]]}
+             (h/run-handler
+              (assoc-in
+               (t-file "sql-multi-transaction")
+               [:parameters :body :query]
+               "SELECT * FROM people"))))))
+
+(t/deftest beta-sql-says-carol-is-red-test
+  (t/testing "XTDB docs example for sql https://docs.xtdb.com/quickstart/sql-overview.html"
+    (t/is (= {:status 200,
+              :body
+              [[:name :favorite_color :_valid_from :_system_from]
+               ["carol"
+                "red"
+                #inst "2023-08-31T23:00:00.000000000-00:00"
+                #inst "2024-01-08T00:00:00.000000000-00:00"]]}
+             (h/run-handler (assoc-in
+                             (t-file "sql-multi-transaction")
+                             [:parameters :body :tx-type]
+                             "sql-beta")))))
+
+  (t/testing "Bob still likes fishing - don't determine columns based on the first row"
+    (t/is (= {:status 200,
+             :body
+             [[:_id :favorite_color :info :likes :name]
+              [2 "red" nil nil "carol"]
+              [9 nil nil ["fishing" 3.14 {:nested "data"}] "bob"]]}
+             (h/run-handler
+              (->  (t-file "sql-multi-transaction")
+                   (assoc-in [:parameters :body :query] "SELECT * FROM people")
+                   (assoc-in [:parameters :body :tx-type] "sql-beta")))))))
+
+(def docs-json
+ "{\"tx-batches\":[{\"txs\":\"[[:sql \\\"INSERT INTO product (_id, name, price) VALUES\\\\n(1, 'An Electric Bicycle', 400)\\\"]]\",\"system-time\":\"2024-01-01\"},{\"txs\":\"[[:sql \\\"UPDATE product SET price = 405 WHERE _id = 1\\\"]]\",\"system-time\":\"2024-01-05\"},{\"txs\":\"[[:sql \\\"UPDATE product SET price = 350 WHERE _id = 1\\\"]]\",\"system-time\":\"2024-01-10\"}],\"query\":\"\\\"SELECT *, _valid_from\\\\nFROM product\\\\nFOR VALID_TIME ALL -- i.e. \\\\\\\"show me all versions\\\\\\\"\\\\nFOR SYSTEM_TIME AS OF DATE '2024-01-31' -- \\\\\\\"...as observed at month end\\\\\\\"\\\"\"}"
+)
+
+(t/deftest docs-run
+  (let [response (h/docs-run-handler {:parameters {:body (json/read-str docs-json :key-fn keyword)}})]
+    (t/testing "docs run returns map results"
+      (t/is
+       (every? map? (:body response))))
+
+    (t/testing "can handle \" strings from docs"
+      (t/is (= {:status 200,
+                :body
+                [{"_id" 1,
+                  "name" "An Electric Bicycle",
+                  "price" 350,
+                  "_valid_from" #time/zoned-date-time "2024-01-10T00:00Z[UTC]"}
+                 {"_id" 1,
+                  "name" "An Electric Bicycle",
+                  "price" 405,
+                  "_valid_from" #time/zoned-date-time "2024-01-05T00:00Z[UTC]"}
+                 {"_id" 1,
+                  "name" "An Electric Bicycle",
+                  "price" 400,
+                  "_valid_from" #time/zoned-date-time "2024-01-01T00:00Z[UTC]"}]}
+               response)))))

--- a/test/clj/xt_play/xtdb_stubs.clj
+++ b/test/clj/xt_play/xtdb_stubs.clj
@@ -1,0 +1,40 @@
+(ns xt-play.xtdb-stubs
+  (:require [clojure.tools.logging :as log]
+            [xt-play.xtdb :as xtdb]))
+
+(def db (atom []))
+(defn- execute! [statement] (swap! db conj statement))
+(defn clean-db [] (reset! db []))
+
+(def resp (atom nil))
+(defn mock-resp [response] (reset! resp response))
+(defn reset-resp [] (mock-resp nil))
+
+(defn with-xtdb [f] (f nil))
+
+(defn submit! [_node txs opts]
+  (log/info :stub-submit-tx txs opts)
+  (execute! txs))
+
+(defn query [_node q]
+  (log/info :stub-query q)
+  (execute! q)
+  (or
+   @resp
+   [{"_id" 2, "col1" "bar", "col2" " baz"} {"_id" 1, "col1" "foo"}]))
+
+(defn with-jdbc [f] (f nil))
+
+(defn jdbc-execute! [_conn statement]
+  (log/info :stub-jdbc-execute! statement)
+  (execute! statement)
+  (or @resp
+      [[:_id :col1 :col2] [2 "bar" " baz"] [1 "foo" nil]]))
+
+(defn with-stubs [f]
+  (with-redefs [xtdb/with-xtdb with-xtdb
+                xtdb/with-jdbc with-jdbc
+                xtdb/submit! submit!
+                xtdb/query query
+                xtdb/jdbc-execute! jdbc-execute!]
+    (f)))

--- a/tests.edn
+++ b/tests.edn
@@ -1,0 +1,2 @@
+#kaocha/v1
+{:tests [{:kaocha.filter/skip-meta [:integration]}]}


### PR DESCRIPTION
This PR contains:

### Moves all side-effecting xtdb actions to their own ns.
Making all fns in the handler more testable with stubs.

### I've also created a stubs ns
Which allows us to make assertions on our data without convoluting it with xtdb responses.
Arguably, `with-stubs` should be a macro mirroring `with-redefs` but I didn't want to go too far into a macro hole before shipping :) 

### Moved the old tests to integration tests 
More work should be done here to:
- make these more pure integration tests, i.e. only test expected xtdb behaviour. 
- create centralised test expected data so that when we run the integration tests, we're running them with the same data we're asserting in the handler.

### Added a workflow action to run the Clojure tests 
Runs all unit tests (excluding integration tests) on every branch.

I could make an argument for blocking merging to master with failing tests, but also don't want to lock up the workflow 😃 

