### PR TITLE
Use beta7.rc2

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,14 +4,9 @@
  {org.clojure/clojure {:mvn/version "1.12.0"}
 
   ;; XTDB dependencies
-  com.xtdb/xtdb-api {:mvn/version "2.0.0-beta6"}
-  com.xtdb/xtdb-jdbc {:mvn/version "2.0.0-beta6"}
-  com.xtdb/xtdb-core {:mvn/version "2.0.0-beta6"
-                      ;; needed since beta6 introduced a protobuf dep
-                      ;; see https://github.com/xtdb/xtdb/issues/4172
-                      :exclusions [com.google.protobuf/protobuf-java]}
-  ;; explicit version, instead of the exclusion
-  com.google.protobuf/protobuf-java {:mvn/version "3.25.5"}
+  com.xtdb/xtdb-api {:mvn/version "2.0.0-beta7.rc2"}
+  com.xtdb/xtdb-jdbc {:mvn/version "2.0.0-beta7.rc2"}
+  com.xtdb/xtdb-core {:mvn/version "2.0.0-beta7.rc2"}
 
   org.postgresql/postgresql {:mvn/version "42.7.4"}
   com.github.seancorfield/next.jdbc {:mvn/version "1.3.939"}
@@ -41,6 +36,7 @@
  {:cljs
   {:extra-paths ["src/cljs"]
    :extra-deps {thheller/shadow-cljs               {:mvn/version "2.26.2"}
+                com.google.protobuf/protobuf-java  {:mvn/version "3.25.5"}
                 re-frame/re-frame                  {:mvn/version "1.4.2"}
                 com.lambdaisland/glogi             {:mvn/version "1.3.169"}
                 applied-science/js-interop         {:mvn/version "0.4.2"}

--- a/src/cljs/xt_play/model/run.cljs
+++ b/src/cljs/xt_play/model/run.cljs
@@ -11,7 +11,7 @@
                                  (tx-batch/batch-list db))}]
     {:method :post
      :uri "/beta-db-run"
-     :params params
+     :params [params]
      :timeout timeout-millis ;; timeout must be greater than the API cold start response time
      :format (ajax/json-request-format)
      :response-format (ajax/json-response-format {:keywords? true})


### PR DESCRIPTION
Make sure we use protobuf 3.x for clojurescript as this is the only version supported by shadow-cljs
https://clojurians.slack.com/archives/C6N245JGG/p1720800467882469?thread_ts=1720793135.323189&cid=C6N245JGG